### PR TITLE
Fix missing RuntimeIdentifier

### DIFF
--- a/ConEmuInside/ConEmuInside.csproj
+++ b/ConEmuInside/ConEmuInside.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>ConEmuInside</RootNamespace>
     <AssemblyName>ConEmuInside</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>

--- a/ConEmuWinForms/ConEmuWinForms.csproj
+++ b/ConEmuWinForms/ConEmuWinForms.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>ConEmu.WinForms</RootNamespace>
     <AssemblyName>ConEmu.WinForms</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>


### PR DESCRIPTION
It appears MSBuild 15.8 or 15.9 requires explicit RuntimeIdentifier=win.

Part of gitextensions/gitextensions#6497