### PR TITLE
Suppress VSTHRD110 warning

### DIFF
--- a/ConEmuWinForms/GlobalSuppressions.cs
+++ b/ConEmuWinForms/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "Upsteam implementation", Scope = "member", Target = "~P:ConEmu.WinForms.ConEmuControl.IsStatusbarVisible")]


### PR DESCRIPTION
The other warnings in GE are handled, this still stick out

```c#
C:\dev\gc\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuControl.cs
(59,77): warning VSTHRD110: Observe the awaitable result of this method call by
 awaiting it, assigning to a variable, or passing it to another method. [C:\dev
\gc\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuWinForms.csproj]
  ConEmuWinForms -> C:\dev\gc\gitextensions\Externals\conemu-inside\ConEmuWinFo
  rms\bin\net6.0-windows\ConEmuWinForms.dll
```