### PR TITLE
Set link click modifyer key to none

### DIFF
--- a/ConEmuWinForms/ConEmuSession.cs
+++ b/ConEmuWinForms/ConEmuSession.cs
@@ -473,7 +473,7 @@ namespace ConEmu.WinForms
 				throw new ArgumentNullException(nameof(dirLocalTempRoot));
 
 			// This one MUST be the last switch
-			cmdl.AppendSwitch("-cmd");
+			cmdl.AppendSwitch("-run");
 
 			// Console mode command
 			// NOTE: if placed AFTER the payload command line, otherwise somehow conemu hooks won't fetch the switch out of the cmdline, e.g. with some complicated git fetch/push cmdline syntax which has a lot of colons inside on itself
@@ -559,6 +559,15 @@ namespace ConEmu.WinForms
 				xmlElem.SetAttribute(ConEmuConstants.XmlAttrName, keyname);
 				xmlElem.SetAttribute("type", "hex");
 				xmlElem.SetAttribute("data", (hostcontext.IsStatusbarVisibleInitial ? 1 : 0).ToString());
+			}
+
+			// Enable "far" editor without a modifier key (default is left control)
+			{
+				string keyname = "FarGotoEditorVk";
+				var xmlElem = ((XmlElement)(xmlSettings.SelectSingleNode($"value[@name='{keyname}']") ?? xmlSettings.AppendChild(xmldoc.CreateElement("value"))));
+				xmlElem.SetAttribute(ConEmuConstants.XmlAttrName, keyname);
+				xmlElem.SetAttribute("type", "hex");
+				xmlElem.SetAttribute("data", 0.ToString());
 			}
 
 			// Environment variables


### PR DESCRIPTION
* Replace deprecated command line parameter `-cmd` with `-run`
-cmd deprecated since 160416
https://conemu.github.io/en/ConEmuArgs.html

* Enable link detection by default without left-ctrl
ConEmu can have clickable links:
![conemu-link](https://github.com/gitextensions/conemu-inside/assets/6248932/93b1fe43-2ee6-43be-b474-af5ab0f6e9cf)

By default left-Ctrl must be pressed to see this feature. The modifier can be changed in settings to none for stand alone ConEmu. The link is then seen when the window is active.

![image](https://github.com/gitextensions/conemu-inside/assets/6248932/0dce0c82-def5-4281-b52e-4fa7ac9103f7)

ConEmu-inside does not read the registry or external ConEmu.xml files for settings, they are the hardcoded defaults except for the few changes in the creation of the session and a few parameters.
The use of left-ctrl is a hidden feature, hard to find without searching for ConEmu settings, example issue::
https://github.com/gitextensions/gitextensions/issues/11097

This PR hardcodes the setting to None.
Other settings like `IsStatusbarVisibleInitial` is explicitly set by GE, if this is merged to upstream then it should be configurable.
Click by default is (basically) the default in terminals like MS Terminal.
For me I see no reason to not have this configurable.
ConEmu is used in two situations:
* Popup, definitely not needing configuration
* Tab. I doubt this will be in the way of the occasional work I expect to be done there. 

Plan to merge #16 before this.